### PR TITLE
Changed button text for process clarity 📝

### DIFF
--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -12,7 +12,7 @@ en:
       request_digital_copy_help_text: Obtain a digitized version of this item.
       select_all: Select All
       clear_all: Clear All
-      submit_request_label: Submit Request
+      submit_request_label: Continue
       close_popup_label: Cancel
       request_unavailable_warning: Record is not available for request.
       toggle_column_label: Toggle selection


### PR DESCRIPTION
In Aeon/public services, we have seen problems that seem to originate with patrons thinking that getting to the Aeon web forms from ArchivesSpace means they have submitted their request to view the materials. There's work to be done on the Aeon side of things, but we'd like to make this small change to the submit button in ArchivesSpace to nudge patrons toward thinking there is more to be done after mashing it.

Happy to talk more about this, and Alison Clemens could be pulled in if needed.