### PR TITLE
Fix: Hide Aeon request buttons for containers with NoRequest parent resources

### DIFF
--- a/backend/model/born_digital_row.rb
+++ b/backend/model/born_digital_row.rb
@@ -9,7 +9,7 @@ class BornDigitalRow < AeonGridRow
     set('collection_title', inherited_json.dig('resource','_resolved','title'))
     set('series_title', (ASUtils.wrap(inherited_json['ancestors']).find{|itm| itm['level'] == 'series'} || {}).dig('_resolved', 'display_string'))
     set('call_number', @request.dig('CallNumber'))
-    set('restrictions', @request.dig('ItemInfo5'))
+    set('restrictions', @request.dig('Transaction.CustomFields.AccessRestrictionNote'))
     set('published', !!solr_doc.dig('publish'))
     set('item_id', inherited_json['component_id'])
     set('item_title', solr_doc['title'])

--- a/backend/model/born_digital_row.rb
+++ b/backend/model/born_digital_row.rb
@@ -9,7 +9,7 @@ class BornDigitalRow < AeonGridRow
     set('collection_title', inherited_json.dig('resource','_resolved','title'))
     set('series_title', (ASUtils.wrap(inherited_json['ancestors']).find{|itm| itm['level'] == 'series'} || {}).dig('_resolved', 'display_string'))
     set('call_number', @request.dig('CallNumber'))
-    set('restrictions', @request.dig('Transaction.CustomFields.AccessRestrictionNote'))
+    set('restrictions', @request.dig('AccessRestrictionNote'))
     set('published', !!solr_doc.dig('publish'))
     set('item_id', inherited_json['component_id'])
     set('item_title', solr_doc['title'])

--- a/backend/model/container_and_item_row.rb
+++ b/backend/model/container_and_item_row.rb
@@ -19,7 +19,7 @@ class ContainerAndItemRow < AeonGridRow
     set('container_title', target_instance.dig('sub_container', 'top_container', '_resolved', 'display_string'))
     set('container_barcode', target_instance.dig('sub_container', 'top_container', '_resolved', 'barcode'))
     set('location', container_location.dig('_resolved', 'title'))
-    set('restrictions', @request.dig('ItemInfo5'))
+    set('restrictions', @request.dig('Transaction.CustomFields.AccessRestrictionNote'))
     set('published', !!solr_doc.dig('publish'))
     set('item_id', inherited_json['component_id'])
     set('item_title', solr_doc['title'])

--- a/backend/model/container_and_item_row.rb
+++ b/backend/model/container_and_item_row.rb
@@ -19,7 +19,7 @@ class ContainerAndItemRow < AeonGridRow
     set('container_title', target_instance.dig('sub_container', 'top_container', '_resolved', 'display_string'))
     set('container_barcode', target_instance.dig('sub_container', 'top_container', '_resolved', 'barcode'))
     set('location', container_location.dig('_resolved', 'title'))
-    set('restrictions', @request.dig('Transaction.CustomFields.AccessRestrictionNote'))
+    set('restrictions', @request.dig('AccessRestrictionNote'))
     set('published', !!solr_doc.dig('publish'))
     set('item_id', inherited_json['component_id'])
     set('item_title', solr_doc['title'])

--- a/backend/model/container_row.rb
+++ b/backend/model/container_row.rb
@@ -13,7 +13,7 @@ class ContainerRow < AeonGridRow
     set('container_title', top_container_json.dig('display_string'))
     set('container_barcode', top_container_json.dig('barcode'))
     set('location', solr_doc.dig('location_display_string_u_sstr', 0))
-    set('restrictions', @request.dig('Transaction.CustomFields.AccessRestrictionNote'))
+    set('restrictions', @request.dig('AccessRestrictionNote'))
     set('published', !!solr_doc.dig('publish'))
   end
 end

--- a/backend/model/container_row.rb
+++ b/backend/model/container_row.rb
@@ -13,7 +13,7 @@ class ContainerRow < AeonGridRow
     set('container_title', top_container_json.dig('display_string'))
     set('container_barcode', top_container_json.dig('barcode'))
     set('location', solr_doc.dig('location_display_string_u_sstr', 0))
-    set('restrictions', @request.dig('ItemInfo5'))
+    set('restrictions', @request.dig('Transaction.CustomFields.AccessRestrictionNote'))
     set('published', !!solr_doc.dig('publish'))
   end
 end

--- a/common/aeon_archival_object_request.rb
+++ b/common/aeon_archival_object_request.rb
@@ -62,24 +62,24 @@ class AeonArchivalObjectRequest
 
     out['restrictions_apply'] = json['restrictions_apply']
 
-    out['ItemInfo14'] = json['resource']['ref']
+    out['Transaction.CustomFields.RootRecordURI'] = json['resource']['ref']
 
     creator = json['linked_agents'].find{|a| a['role'] == 'creator'}
 
     out['ItemAuthor'] = creator['_resolved']['title'] if creator
-    out['ItemInfo5'] = AeonRequest.access_restrictions_content(json['notes'])
+    out['Transaction.CustomFields.AccessRestrictionNote'] = AeonRequest.access_restrictions_content(json['notes'])
 
-    out['ItemInfo6'] = json['notes'].select {|n| n['type'] == 'userestrict'}
+    out['Transaction.CustomFields.UseRestrictionNote'] = json['notes'].select {|n| n['type'] == 'userestrict'}
       .map {|n| n['subnotes'].map {|s| s['content']}.join(' ')}
       .join(' ')
 
-    out['ItemInfo7'] = json['extents'].select {|e| !e.has_key?('_inherited')}
+    out['Transaction.CustomFields.ExtentPhysicalDescription'] = json['extents'].select {|e| !e.has_key?('_inherited')}
       .map {|e| "#{e['number']} #{e['extent_type']}"}.join('; ')
 
-    out['ItemInfo8'] = AeonRequest.local_access_restrictions(json['notes'])
+    out['Transaction.CustomFields.RestrictionCode'] = AeonRequest.local_access_restrictions(json['notes'])
 
     unless (digital_objects = opts.fetch(:resolved_digital_objects, json['instances'].map{|instance| instance.dig('digital_object', '_resolved')}.compact)).empty?
-      out['ItemInfo9'] = digital_objects.map{|do_json| "#{JSONModel(:digital_object).id_for(do_json.fetch('uri'))} (#{do_json.fetch('publish') ? 'P' : 'U'})"}.uniq.join('; ')
+      out['Transaction.CustomFields.DigitalObjectID'] = digital_objects.map{|do_json| "#{JSONModel(:digital_object).id_for(do_json.fetch('uri'))} (#{do_json.fetch('publish') ? 'P' : 'U'})"}.uniq.join('; ')
     end
 
     out['component_id'] = json['component_id']

--- a/common/aeon_archival_object_request.rb
+++ b/common/aeon_archival_object_request.rb
@@ -62,24 +62,24 @@ class AeonArchivalObjectRequest
 
     out['restrictions_apply'] = json['restrictions_apply']
 
-    out['Transaction.CustomFields.RootRecordURI'] = json['resource']['ref']
+    out['RootRecordURI'] = json['resource']['ref']
 
     creator = json['linked_agents'].find{|a| a['role'] == 'creator'}
 
     out['ItemAuthor'] = creator['_resolved']['title'] if creator
-    out['Transaction.CustomFields.AccessRestrictionNote'] = AeonRequest.access_restrictions_content(json['notes'])
+    out['AccessRestrictionNote'] = AeonRequest.access_restrictions_content(json['notes'])
 
-    out['Transaction.CustomFields.UseRestrictionNote'] = json['notes'].select {|n| n['type'] == 'userestrict'}
+    out['UseRestrictionNote'] = json['notes'].select {|n| n['type'] == 'userestrict'}
       .map {|n| n['subnotes'].map {|s| s['content']}.join(' ')}
       .join(' ')
 
-    out['Transaction.CustomFields.ExtentPhysicalDescription'] = json['extents'].select {|e| !e.has_key?('_inherited')}
+    out['ExtentPhysicalDescription'] = json['extents'].select {|e| !e.has_key?('_inherited')}
       .map {|e| "#{e['number']} #{e['extent_type']}"}.join('; ')
 
-    out['Transaction.CustomFields.RestrictionCode'] = AeonRequest.local_access_restrictions(json['notes'])
+    out['RestrictionCode'] = AeonRequest.local_access_restrictions(json['notes'])
 
     unless (digital_objects = opts.fetch(:resolved_digital_objects, json['instances'].map{|instance| instance.dig('digital_object', '_resolved')}.compact)).empty?
-      out['Transaction.CustomFields.DigitalObjectID'] = digital_objects.map{|do_json| "#{JSONModel(:digital_object).id_for(do_json.fetch('uri'))} (#{do_json.fetch('publish') ? 'P' : 'U'})"}.uniq.join('; ')
+      out['DigitalObjectID'] = digital_objects.map{|do_json| "#{JSONModel(:digital_object).id_for(do_json.fetch('uri'))} (#{do_json.fetch('publish') ? 'P' : 'U'})"}.uniq.join('; ')
     end
 
     out['component_id'] = json['component_id']

--- a/common/aeon_request.rb
+++ b/common/aeon_request.rb
@@ -77,7 +77,7 @@ class AeonRequest
 
       request["instance_top_container_ref"] = container['top_container']['ref']
 
-      request['ItemEdition'] = ['2', '3'].map {|lvl|
+      request['ItemFolder'] = ['2', '3'].map {|lvl|
         (container["type_#{lvl}"] || '').downcase == 'folder' ? container["indicator_#{lvl}"] : nil
       }.compact.join('; ')
 

--- a/common/aeon_request.rb
+++ b/common/aeon_request.rb
@@ -120,10 +120,10 @@ class AeonRequest
 
     request["ReferenceNumber"] = request["instance_top_container_barcode"]
 
-    request['ItemInfo1'] = json['restricted'] ? 'Y' : 'N'
+    request['Transaction.CustomFields.TopContainerRestriction'] = json['restricted'] ? 'Y' : 'N'
 
     request['ItemVolume'] = json['display_string'][0, (json['display_string'].index(':') || json['display_string'].length)]
-    request['ItemInfo10'] = json['uri']
+    request['Transaction.CustomFields.TopContainerURI'] = json['uri']
     request["ItemIssue"] = json['series'].map{|s| s['level_display_string'] + ' ' + s['identifier'] + '. ' + s['display_string']}.join('; ')
 
     if (loc = json['container_locations'].find{|cl| cl['status'] == 'current'})
@@ -132,8 +132,8 @@ class AeonRequest
         request['instance_top_container_long_display_string'] = request['Location']
       end
 
-      # ItemInfo11 (location uri)
-      request["ItemInfo11"] = loc['ref']
+      # Location URI
+      request["Transaction.CustomFields.LocationURI"] = loc['ref']
     else
       # added this so that we don't wind up with the default Aeon mapping here, which maps the top container long display name to the location.
       request['instance_top_container_long_display_string'] = nil

--- a/common/aeon_request.rb
+++ b/common/aeon_request.rb
@@ -120,10 +120,10 @@ class AeonRequest
 
     request["ReferenceNumber"] = request["instance_top_container_barcode"]
 
-    request['Transaction.CustomFields.TopContainerRestriction'] = json['restricted'] ? 'Y' : 'N'
+    request['TopContainerRestriction'] = json['restricted'] ? 'Y' : 'N'
 
     request['ItemVolume'] = json['display_string'][0, (json['display_string'].index(':') || json['display_string'].length)]
-    request['Transaction.CustomFields.TopContainerURI'] = json['uri']
+    request['TopContainerURI'] = json['uri']
     request["ItemIssue"] = json['series'].map{|s| s['level_display_string'] + ' ' + s['identifier'] + '. ' + s['display_string']}.join('; ')
 
     if (loc = json['container_locations'].find{|cl| cl['status'] == 'current'})
@@ -133,7 +133,7 @@ class AeonRequest
       end
 
       # Location URI
-      request["Transaction.CustomFields.LocationURI"] = loc['ref']
+      request["LocationURI"] = loc['ref']
     else
       # added this so that we don't wind up with the default Aeon mapping here, which maps the top container long display name to the location.
       request['instance_top_container_long_display_string'] = nil

--- a/common/aeon_request.rb
+++ b/common/aeon_request.rb
@@ -124,7 +124,7 @@ class AeonRequest
 
     request['ItemVolume'] = json['display_string'][0, (json['display_string'].index(':') || json['display_string'].length)]
     request['TopContainerURI'] = json['uri']
-    request["ItemIssue"] = json['series'].map{|s| s['level_display_string'] + ' ' + s['identifier'] + '. ' + s['display_string']}.join('; ')
+    request["ItemSeries"] = json['series'].map{|s| s['level_display_string'] + ' ' + s['identifier'] + '. ' + s['display_string']}.join('; ')
 
     if (loc = json['container_locations'].find{|cl| cl['status'] == 'current'})
       if (resolved_location = loc['_resolved'])

--- a/common/aeon_top_container_request.rb
+++ b/common/aeon_top_container_request.rb
@@ -12,16 +12,16 @@ class AeonTopContainerRequest
 
     restrictions_notes = json['active_restrictions'].map {|a| a['linked_records']['_resolved']['notes']}.flatten
     out['accessrestrict'] = AeonRequest.access_restrictions_content(restrictions_notes)
-    out['ItemInfo5'] = out['accessrestrict']
-    out['ItemInfo8'] = AeonRequest.local_access_restrictions(restrictions_notes)
+    out['Transaction.CustomFields.AccessRestrictionNote'] = out['accessrestrict']
+    out['Transaction.CustomFields.RestrictionCode'] = AeonRequest.local_access_restrictions(restrictions_notes)
 
-    out['ItemInfo12'] = out['collection_title']
+    out['Transaction.CustomFields.CollectionTitle'] = out['collection_title']
 
     out['DocumentType'] = AeonRequest.doc_type(json, out['collection_id'])
     out['WebRequestForm'] = AeonRequest.web_request_form(json, out['collection_id'])
 
     out['CallNumber'] = json['collection'].map {|c| c['identifier']}.join('; ')
-    out['ItemInfo14'] = json['collection'].map {|c| c['ref']}.join('; ')
+    out['Transaction.CustomFields.RootRecordURI'] = json['collection'].map {|c| c['ref']}.join('; ')
 
     if cp = json['container_profile']
       out['SubLocation'] = cp['_resolved']['name']

--- a/common/aeon_top_container_request.rb
+++ b/common/aeon_top_container_request.rb
@@ -12,16 +12,16 @@ class AeonTopContainerRequest
 
     restrictions_notes = json['active_restrictions'].map {|a| a['linked_records']['_resolved']['notes']}.flatten
     out['accessrestrict'] = AeonRequest.access_restrictions_content(restrictions_notes)
-    out['Transaction.CustomFields.AccessRestrictionNote'] = out['accessrestrict']
-    out['Transaction.CustomFields.RestrictionCode'] = AeonRequest.local_access_restrictions(restrictions_notes)
+    out['AccessRestrictionNote'] = out['accessrestrict']
+    out['RestrictionCode'] = AeonRequest.local_access_restrictions(restrictions_notes)
 
-    out['Transaction.CustomFields.CollectionTitle'] = out['collection_title']
+    out['CollectionTitle'] = out['collection_title']
 
     out['DocumentType'] = AeonRequest.doc_type(json, out['collection_id'])
     out['WebRequestForm'] = AeonRequest.web_request_form(json, out['collection_id'])
 
     out['CallNumber'] = json['collection'].map {|c| c['identifier']}.join('; ')
-    out['Transaction.CustomFields.RootRecordURI'] = json['collection'].map {|c| c['ref']}.join('; ')
+    out['RootRecordURI'] = json['collection'].map {|c| c['ref']}.join('; ')
 
     if cp = json['container_profile']
       out['SubLocation'] = cp['_resolved']['name']

--- a/public/locales/en.yml
+++ b/public/locales/en.yml
@@ -12,7 +12,7 @@ en:
       request_digital_copy_help_text: Obtain a digitized version of this item.
       select_all: Select All
       clear_all: Clear All
-      submit_request_label: Submit Request
+      submit_request_label: Continue
       close_popup_label: Cancel
       request_unavailable_warning: Record is not available for request.
       toggle_column_label: Toggle selection

--- a/public/models/aeon_accession_mapper.rb
+++ b/public/models/aeon_accession_mapper.rb
@@ -9,8 +9,6 @@ class AeonAccessionMapper < AeonRecordMapper
     def system_information
         mapped = super
 
-        # Should ask that AUG update the Aeon database at the time this mapping goes into place.
-        # If so, they'd just need to move over data from ItemInfo2 to EADNumber for the ArchivesSpace requests up until that date.
         mapped['EADNumber'] = mapped['ReturnLinkURL']
 
         # Site (repo_code)
@@ -37,13 +35,13 @@ class AeonAccessionMapper < AeonRecordMapper
         end
 
         # Access restriction notes
-        mappings['Transaction.CustomFields.AccessRestrictionNote'] = json['access_restrictions_note']
+        mappings['AccessRestrictionNote'] = json['access_restrictions_note']
 
         # Use restrictions note
-        mappings['Transaction.CustomFields.UseRestrictionNote'] = json['use_restrictions_note']
+        mappings['UseRestrictionNote'] = json['use_restrictions_note']
 
         # Extents
-        mappings['Transaction.CustomFields.ExtentPhysicalDescription'] = json['extents'].select {|e| !e.has_key?('_inherited')}
+        mappings['ExtentPhysicalDescription'] = json['extents'].select {|e| !e.has_key?('_inherited')}
                                              .map {|e| "#{e['number']} #{e['extent_type']}"}.join('; ')
 
         # ItemAuthor (creators)

--- a/public/models/aeon_accession_mapper.rb
+++ b/public/models/aeon_accession_mapper.rb
@@ -36,14 +36,14 @@ class AeonAccessionMapper < AeonRecordMapper
             mappings['collection_id'] += '; ' + json['user_defined']['text_1'] if json['user_defined']['text_1']
         end
 
-        # ItemInfo5 (access restriction notes)
-        mappings['ItemInfo5'] = json['access_restrictions_note']
+        # Access restriction notes
+        mappings['Transaction.CustomFields.AccessRestrictionNote'] = json['access_restrictions_note']
 
-        # ItemInfo6 (use_restrictions_note)
-        mappings['ItemInfo6'] = json['use_restrictions_note']
+        # Use restrictions note
+        mappings['Transaction.CustomFields.UseRestrictionNote'] = json['use_restrictions_note']
 
-        # ItemInfo7 (extents)
-        mappings['ItemInfo7'] = json['extents'].select {|e| !e.has_key?('_inherited')}
+        # Extents
+        mappings['Transaction.CustomFields.ExtentPhysicalDescription'] = json['extents'].select {|e| !e.has_key?('_inherited')}
                                              .map {|e| "#{e['number']} #{e['extent_type']}"}.join('; ')
 
         # ItemAuthor (creators)

--- a/public/models/aeon_container_mapper.rb
+++ b/public/models/aeon_container_mapper.rb
@@ -1,5 +1,62 @@
 class AeonContainerMapper < AeonRecordMapper
-
   register_for_record_type(Container)
 
+  # Override hide_button? to check parent resource restrictions
+  def hide_button?
+    # First check the standard restrictions on the container itself
+    return true if super
+    
+    # For containers, also check if the parent resource has "No Request" restriction
+    return true if parent_resource_has_no_request_restriction?
+    
+    false
+  end
+
+private
+
+  def parent_resource_has_no_request_restriction?
+    Rails.logger.info("Aeon debug: Checking container #{@record.json['uri']} for NoRequest restriction")
+
+    # Get the parent resource from the container
+    resource = get_parent_resource
+    Rails.logger.info("Aeon debug: Container #{@record.json['uri']} - Parent resource: #{resource ? resource['uri'] : 'NONE'}")
+
+    return false unless resource
+    
+    # Check if the resource has "No Request" restriction in its access restrict notes
+    resource_restriction_types = extract_restriction_types_from_resource(resource)
+    has_no_request = resource_restriction_types.include?(RESTRICTION_TYPE_NO_REQUEST)
+    
+    Rails.logger.info("Aeon debug: Parent resource restrictions: #{resource_restriction_types}, Has NoRequest: #{has_no_request}")
+    Rails.logger.info("Aeon debug: Final result - hiding request buttons: #{has_no_request}")
+    
+    has_no_request
+  end
+
+  def get_parent_resource
+    # For containers, the parent resource is referenced in created_for_collection
+    collection_uri = @record.json['created_for_collection']
+    return nil unless collection_uri
+    
+    begin
+      # Fetch the resource record
+      resource_response = archivesspace.get_record(collection_uri)
+      return resource_response if resource_response && resource_response['json']
+    rescue => e
+      Rails.logger.error("Aeon Fulfillment Plugin") { "Failed to fetch parent resource #{collection_uri}: #{e.message}" }
+      return nil
+    end
+    
+    nil
+  end
+
+  def extract_restriction_types_from_resource(resource)
+    resource_json = resource['json'] || {}
+    
+    (resource_json['notes'] || [])
+      .select { |n| n['type'] == 'accessrestrict' && n.has_key?('rights_restriction') }
+      .map { |n| n['rights_restriction']['local_access_restriction_type'] }
+      .flatten
+      .uniq
+  end
 end


### PR DESCRIPTION
## Fix: Hide Aeon request buttons for containers with NoRequest parent resources

### Problem
Container pages were showing Aeon request buttons even when the parent resource had "NoRequest" access restriction, allowing users to request items that shouldn't be requestable.

### Solution  
- Added logic in AeonContainerMapper to check parent resource restrictions
- Override hide_button? method to include parent resource restriction check
- Added debug logging for Test environment troubleshooting

### Testing

Verified:
- containers with NoRequest parent resource hide the request button
- containers without NoRequest parent resource show the request button
- existing functionality unchanged for other restriction types

### Deployment Notes
- Contains debug logging for Test environment
- Will remove debug logs before Production deployment